### PR TITLE
Improve reporting

### DIFF
--- a/DKIM/Verify.php
+++ b/DKIM/Verify.php
@@ -243,7 +243,7 @@ class DKIM_Verify extends DKIM {
                 } else {
                     $results[$num][] = array (
                         'status' => 'pass',
-                        'reason' => 'Header signature is valid',
+                        'reason' => 'Computed header hash matches signature header hash',
                     );
                 }
             }

--- a/DKIM/Verify.php
+++ b/DKIM/Verify.php
@@ -100,7 +100,14 @@ class DKIM_Verify extends DKIM {
                     switch ($qFormat) {
                         case 'txt':
                             $this->_publicKeys[$dkim['d']] = self::fetchPublicKey($dkim['d'], $dkim['s']);
-
+                            if (!$this->_publicKeys[$dkim['d']]) {
+                                $results[$num][] = array (
+                                    'status' => 'permfail',
+                                    'reason' => 'Public key unavailable (TXT record was not available)',
+                                );
+                                $abort = true;
+                                continue;
+                            }
                             break;
                         default:
                             $results[$num][] = array (

--- a/DKIM/Verify.php
+++ b/DKIM/Verify.php
@@ -238,7 +238,7 @@ class DKIM_Verify extends DKIM {
                 if (!$vResult) {
                     $results[$num][] = array (
                         'status' => 'permfail',
-                        'reason' => "signature did not verify ({$dkim['d']} key #$knum)",
+                        'reason' => "Signature did not verify ({$dkim['d']} key #$knum)",
                     );
                 } else {
                     $results[$num][] = array (

--- a/DKIM/Verify.php
+++ b/DKIM/Verify.php
@@ -53,7 +53,7 @@ class DKIM_Verify extends DKIM {
                 if (!isset($dkim[$key])) {
                     $results[$num][] = array (
                         'status' => 'permfail',
-                        'reason' => "signature missing required tag: $key",
+                        'reason' => "Signature missing required tag: $key",
                     );
                     continue;
                 }
@@ -66,7 +66,7 @@ class DKIM_Verify extends DKIM {
             if ($dkim['v'] != 1) {
                 $results[$num][] = array (
                     'status' => 'permfail',
-                    'reason' => 'incompatible version: ' . $dkim['v'],
+                    'reason' => 'Incompatible version: ' . $dkim['v'],
                 );
                 continue;
             }
@@ -227,7 +227,7 @@ class DKIM_Verify extends DKIM {
                 if ( !class_exists('Crypt_RSA') && !defined('OPENSSL_ALGO_'.strtoupper($hash)) ) {
                     $results[$num][] = array (
                         'status' => 'permfail',
-                        'reason' => " Signature Algorithm $hash does not available for openssl_verify(), key #$knum)",
+                        'reason' => "Signature Algorithm $hash does not available for openssl_verify(), key #$knum)",
                     );
                     continue;
                 }

--- a/DKIM/Verify.php
+++ b/DKIM/Verify.php
@@ -105,8 +105,6 @@ class DKIM_Verify extends DKIM {
                                     'status' => 'permfail',
                                     'reason' => 'Public key unavailable (TXT record was not available)',
                                 );
-                                $abort = true;
-                                continue;
                             }
                             break;
                         default:

--- a/DKIM/Verify.php
+++ b/DKIM/Verify.php
@@ -156,7 +156,12 @@ class DKIM_Verify extends DKIM {
             // Hash/encode the body
             $bh = self::_hashBody($cBody, $hash);
 
-            if ($bh !== $dkim['bh']) {
+            if ($bh === $dkim['bh']) {
+                $results[$num][] = array (
+                    'status' => 'pass',
+                    'reason' => 'Computed body hash matches signature body hash',
+                );
+            } else {
                 $results[$num][] = array (
                     'status' => 'permfail',
                     'reason' => "Computed body hash does not match signature body hash",
@@ -238,7 +243,7 @@ class DKIM_Verify extends DKIM {
                 } else {
                     $results[$num][] = array (
                         'status' => 'pass',
-                        'reason' => 'Success!',
+                        'reason' => 'Header signature is valid',
                     );
                 }
             }


### PR DESCRIPTION
When given a mail with correct header but mangled body, the result would be both permfail and pass, but when a mail is correct only pass is returned.

No results are returned when the DKIM signature contains a key that doesn't exist in DNS.

This pull request seeks to remedy by returning success both for the header and the body if these are correct, and by adding an error for missing TXT records in DNS.